### PR TITLE
ESIMW-1002: Added configuration for publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.iu.uits</groupId>
     <artifactId>javamail-smime-transport</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>JavaMail S/MIME Transport</name>
     <description>A JavaMail Transport which will add an S/MIME signature to outgoing emails</description>
@@ -17,6 +17,15 @@
         <name>Indiana University - UITS</name>
         <url>https://uits.iu.edu</url>
     </organization>
+
+    <developers>
+        <developer>
+            <name>ESI Middleware Team</name>
+            <email>esireq@iu.edu</email>
+            <organization>Indiana University - UITS</organization>
+            <organizationUrl>https://uits.iu.edu</organizationUrl>
+        </developer>
+    </developers>
 
     <issueManagement>
         <system>GitHub</system>
@@ -30,6 +39,19 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <distributionManagement>
+        <repository>
+            <name>Sonatype OSS Repository</name>
+            <id>Sonatype-OSS</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+            <name>Sonatype OSS Snapshot Repository</name>
+            <id>Sonatype-OSS</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <scm>
         <connection>scm:git:https://github.com/indiana-university/javamail-smime-transport.git</connection>
@@ -46,6 +68,14 @@
         <logback.version>1.2.3</logback.version>
         <lombok.version>1.16.22</lombok.version>
         <slf4j.version>1.7.25</slf4j.version>
+
+        <!-- Plugin Versions -->
+        <plugins.compiler.version>3.7.0</plugins.compiler.version>
+        <plugins.gpg.version>1.6</plugins.gpg.version>
+        <plugins.javadoc.version>3.0.1</plugins.javadoc.version>
+        <plugins.nexus-staging.version>1.6.8</plugins.nexus-staging.version>
+        <plugins.release.version>2.5.3</plugins.release.version>
+        <plugins.source.version>3.0.1</plugins.source.version>
 
         <!-- Project Metadata -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -134,12 +164,85 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${plugins.compiler.version}</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${plugins.nexus-staging.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>Sonatype-OSS</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${plugins.release.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${plugins.source.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${plugins.javadoc.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${plugins.gpg.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
* Switched version number to <major>.<minor>.<patch> scheme
* Added developers section to POM
* Added distribution management setting the Sonatype OSS repositories
* Added configuration for the Maven release plugin and the Sonatype nexus-staging plugin
* Added a release profile which will build source and JavaDoc JARS and sign everything before deploying them

This change requires some additions to the Maven `settings.xml` file:

* Add the `Sonatype-OSS` server with a username/password for deploying Maven artifacts:
  ```xml
  <server>
    <id>Sonatype-OSS</id>
    <username>...</username>
    <password>...</password>
  </server>
  ```
* Add the `gpg.passphrase` server with a passphrase for the GPG used for signing artifacts:
  ```xml
  <server>
    <id>gpg.passphrase</id>
    <passphrase>...</passphrase>
  </server>
  ```
* Add a default Maven profile if one does not exist and set the key ID of the GPG key used for signing artifacts:
  ```xml
  <profiles>
    <profile>
      <id>default</id>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
        <gpg.keyname>...</gpg.keyname>
      </properties>
    </profile>
   </profiles>
  ```
