### PR TITLE
ESIMW-1002: Auto-release artifact from Sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
                 <configuration>
                     <serverId>Sonatype-OSS</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Reconfigure the Sonatype Nexus Staging plugin so it automatically releases the artifact to Maven Central once all of the checks are passing