### PR TITLE
ESIMW-1166: Preserve content type and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,6 @@
         </profile>
         <profile>
             <id>integration-tests</id>
-            <properties>
-                <profiles.active>filesystem-logging</profiles.active>
-            </properties>
             <activation>
                 <property>
                     <name>maven.failsafe.skip</name>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <properties>
         <!-- Dependency Versions -->
         <bouncycastle.version>1.46</bouncycastle.version>
+        <jacoco.version>0.8.1</jacoco.version>
         <java-mail.version>1.6.1</java-mail.version>
         <junit.jupiter.version>5.2.0</junit.jupiter.version>
         <junit.platform.version>1.2.0</junit.platform.version>
@@ -70,7 +71,9 @@
         <slf4j.version>1.7.25</slf4j.version>
 
         <!-- Plugin Versions -->
+        <plugins.build-helper.version>3.0.0</plugins.build-helper.version>
         <plugins.compiler.version>3.7.0</plugins.compiler.version>
+        <plugins.failsafe.version>2.18.1</plugins.failsafe.version>
         <plugins.gpg.version>1.6</plugins.gpg.version>
         <plugins.javadoc.version>3.0.1</plugins.javadoc.version>
         <plugins.nexus-staging.version>1.6.8</plugins.nexus-staging.version>
@@ -127,6 +130,16 @@
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.icegreen</groupId>
+                <artifactId>greenmail</artifactId>
+                <version>1.5.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>1.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -169,10 +182,45 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.icegreen</groupId>
+            <artifactId>greenmail</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>${plugins.build-helper.version}</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/it/java</source>
+                            </sources>
+                            <resources>
+                                <resource>
+                                    <directory>src/it/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${plugins.compiler.version}</version>
@@ -258,6 +306,62 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration-tests</id>
+            <properties>
+                <profiles.active>filesystem-logging</profiles.active>
+            </properties>
+            <activation>
+                <property>
+                    <name>maven.failsafe.skip</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${plugins.failsafe.version}</version>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <encoding>${project.build.sourceEncoding}</encoding>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent-integration</id>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report-integration</id>
+                                <goals>
+                                    <goal>report-integration</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
     <properties>
         <!-- Dependency Versions -->
         <bouncycastle.version>1.46</bouncycastle.version>
+        <greenmail.version>1.5.7</greenmail.version>
+        <hamcrest-core.version>1.3</hamcrest-core.version>
         <jacoco.version>0.8.1</jacoco.version>
         <java-mail.version>1.6.1</java-mail.version>
         <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -133,12 +135,12 @@
             <dependency>
                 <groupId>com.icegreen</groupId>
                 <artifactId>greenmail</artifactId>
-                <version>1.5.7</version>
+                <version>${greenmail.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
+                <version>${hamcrest-core.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/it/java/edu/iu/uits/mail/SignedEmailIT.java
+++ b/src/it/java/edu/iu/uits/mail/SignedEmailIT.java
@@ -1,0 +1,160 @@
+package edu.iu.uits.mail;
+
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.GreenMailUtil;
+import com.icegreen.greenmail.util.ServerSetup;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+
+public class SignedEmailIT {
+
+    private Properties properties = new Properties();
+    private GreenMail greenMail;
+    private Session session;
+
+
+    private static final int SMTP_PORT = 4025;
+    private static final String SMTP_PROTOCOL = "smtp+smime";
+    private static final String EMAIL_ADDRESS_WITH_CERT = "workflow.noreply@iu.edu";
+    private static final String EMAIL_ADDRESS_WITHOUT_CERT = "workflow.nocert.iu.edu";
+
+    @Before
+    public void setup() throws IOException {
+        final InputStream input = new FileInputStream("/opt/j2ee/security/kr/rice-keystore.properties");
+        Properties riceProperties = new Properties();
+        riceProperties.load(input);
+
+        properties.put("mail.keystore.file",  riceProperties.getProperty("keystore.file"));
+        properties.put("mail.keystore.password", riceProperties.getProperty("keystore.password"));
+        properties.put("mail.keystore.workflow.noreply.password", riceProperties.getProperty("workflow.noreply@iu.edu"));
+
+        final ServerSetup serverSetup = new ServerSetup(SMTP_PORT, null, SMTP_PROTOCOL);
+
+        greenMail = new GreenMail(serverSetup);
+        greenMail.start();
+
+        session = GreenMailUtil.getSession(serverSetup, properties);
+
+    }
+
+    @After
+    public void tearDown() {
+        greenMail.stop();
+    }
+
+
+    @Test
+    @DisplayName("Test that a basic email is signed")
+    public void testTextEmailIsSigned() throws MessagingException {
+        MimeMessage msg = new MimeMessage(session);
+        msg.setText("content");
+        msg.setFrom(new InternetAddress(EMAIL_ADDRESS_WITH_CERT));
+        msg.addRecipient(Message.RecipientType.TO,
+                new InternetAddress("bar@example.com"));
+        msg.setSubject("Testing signed text email");
+        Transport.send(msg);
+
+        Message message = getMessage();
+
+        assertTrue(hasSignedContentType(message));
+    }
+
+    @Test
+    @DisplayName("Test that an email sent from an address without a certificate is not signed")
+    public void testEmailAddressWithoutCertIsNotSigned() throws MessagingException {
+        MimeMessage msg = new MimeMessage(session);
+        msg.setText("content");
+        msg.setFrom(new InternetAddress(EMAIL_ADDRESS_WITHOUT_CERT));
+        msg.addRecipient(Message.RecipientType.TO,
+                new InternetAddress("bar@example.com"));
+        msg.setSubject("Testing email address without cert");
+        Transport.send(msg);
+
+        Message message = getMessage();
+
+        assertFalse(hasSignedContentType(message));
+    }
+
+    @Test
+    @DisplayName("Test that text/html emails are signed")
+    public void testTextHtmlEmailIsSigned() throws MessagingException {
+        MimeMessage msg = new MimeMessage(session);
+        msg.setHeader("Content-Type", "text/html");
+        msg.setText("<p>content</p>");
+        msg.setFrom(new InternetAddress(EMAIL_ADDRESS_WITH_CERT));
+        msg.addRecipient(Message.RecipientType.TO,
+                new InternetAddress("bar@example.com"));
+        msg.setSubject("Testing signed text/html email");
+        Transport.send(msg);
+
+        Message message = getMessage();
+
+        assertTrue(hasSignedContentType(message));
+
+    }
+
+
+    @Test
+    @DisplayName("Test that a multi-part email is properly signed")
+    public void testMultipartEmailIsSigned() throws MessagingException {
+        Message msg = new MimeMessage(session);
+        Multipart multiPart = new MimeMultipart("alternative");
+
+        MimeBodyPart textPart = new MimeBodyPart();
+        textPart.setText("text content", "utf-8");
+
+        MimeBodyPart htmlPart = new MimeBodyPart();
+        htmlPart.setContent("<p>html content</p>", "text/html; charset=utf-8");
+
+        multiPart.addBodyPart(htmlPart);
+        multiPart.addBodyPart(textPart);
+        msg.setContent(multiPart);
+
+        msg.setFrom(new InternetAddress(EMAIL_ADDRESS_WITH_CERT));
+        msg.addRecipient(Message.RecipientType.TO,
+                new InternetAddress("bar@example.com"));
+        msg.setSubject("Testing signed multipart email");
+        Transport.send(msg);
+
+        Message message = getMessage();
+
+        assertTrue(hasSignedContentType(message));
+
+    }
+
+    private boolean hasSignedContentType(Message message) throws MessagingException {
+        Enumeration<Header> headers = message.getAllHeaders();
+        while (headers.hasMoreElements()) {
+            Header header = headers.nextElement();
+            System.out.println(String.format("%s : %s", header.getName(), header.getValue()));
+            if (header.getName().equals("Content-Type")) {
+                return header.getValue().contains("multipart/signed; protocol=\"application/pkcs7-signature\";");
+            }
+        }
+        return false;
+    }
+
+    private Message getMessage() {
+        Message[] messages = greenMail.getReceivedMessages();
+        assertEquals(1, messages.length);
+        return  messages[0];
+    }
+}
+

--- a/src/main/java/edu/iu/uits/mail/MailSigner.java
+++ b/src/main/java/edu/iu/uits/mail/MailSigner.java
@@ -140,9 +140,9 @@ public class MailSigner {
             MimeBodyPart mimeBodyPart = new MimeBodyPart();
             Object messageContent = message.getContent();
             if (messageContent instanceof String) {
-                mimeBodyPart.setText((String) messageContent);
+                mimeBodyPart.setContent(messageContent, message.getContentType());
             } else if (messageContent instanceof MimeMultipart) {
-                mimeBodyPart.setContent((MimeMultipart) messageContent, message.getContentType());
+                mimeBodyPart.setContent((MimeMultipart)messageContent);
             }
 
             MimeMultipart signedMultipart = gen.generate(mimeBodyPart);


### PR DESCRIPTION
Ensure that the content type passed to the mail signer in preserved in the inner message that is sent