### PR TITLE
ESIMW-1707: Fix compiler plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
         <!-- Plugin Versions -->
         <plugins.build-helper.version>3.0.0</plugins.build-helper.version>
-        <plugins.compiler.version>3.8.0-jboss-2</plugins.compiler.version>
+        <plugins.compiler.version>3.8.1</plugins.compiler.version>
         <plugins.failsafe.version>2.18.1</plugins.failsafe.version>
         <plugins.gpg.version>1.6</plugins.gpg.version>
         <plugins.javadoc.version>3.0.1</plugins.javadoc.version>


### PR DESCRIPTION
Not sure why the last PR built, etc. for me locally, but this gets rid of an invalid version of the `maven-compiler-plugin`